### PR TITLE
Added ability to remove all saved keychain data for debug proposes. 

### DIFF
--- a/MKStoreManager.h
+++ b/MKStoreManager.h
@@ -73,6 +73,8 @@
 - (BOOL) canConsumeProduct:(NSString*) productName quantity:(int) quantity;
 - (BOOL) consumeProduct:(NSString*) productName quantity:(int) quantity;
 - (BOOL) isSubscriptionActive:(NSString*) featureId;
+//for testing proposes you can use this method to remove all the saved keychain data (saved purchases, etc.)
+- (BOOL) removeAllKeychainData;
 
 +(void) setObject:(id) object forKey:(NSString*) key;
 +(NSNumber*) numberForKey:(NSString*) key;

--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -249,7 +249,30 @@ static MKStoreManager* _sharedStoreManager;
 	request.delegate = self;
 	[request start];
 }
-
+- (BOOL) removeAllKeychainData {
+    NSMutableArray *productsArray = [NSMutableArray array];
+    NSArray *consumables = [[[self storeKitItems] objectForKey:@"Consumables"] allKeys];
+    NSArray *nonConsumables = [[self storeKitItems] objectForKey:@"Non-Consumables"];
+    NSArray *subscriptions = [[[self storeKitItems] objectForKey:@"Subscriptions"] allKeys];
+    
+    [productsArray addObjectsFromArray:consumables];
+    [productsArray addObjectsFromArray:nonConsumables];
+    [productsArray addObjectsFromArray:subscriptions];
+    
+    int itemCount = productsArray.count;
+    NSError *error;
+    
+    //loop through all the saved keychain data and remove it    
+    for (int i = 0; i < itemCount; i++ ) {
+        [SFHFKeychainUtils deleteItemForUsername:[productsArray objectAtIndex:i] andServiceName:@"MKStoreKit" error:&error];
+    }
+    if (!error) {
+        return YES; 
+    }
+    else {
+        return NO;
+    }
+}
 
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response
 {


### PR DESCRIPTION
Mugunth,

MKStoreKit 4.0 is really awesome, thanks a lot. 

I was trying to test in app purchases and I noticed that even after removing the app from the device, the app still remembered that I had purchased an item. 

Apparently, the keychain is not cleared after removing an app: http://stackoverflow.com/questions/3884847/when-are-ios-keychain-items-removed

This makes it very difficult to debug an app with in app purchases. That is why I created a simple method to remove all the keychain data, removeAllKeychainData.

Hopefully, you find this useful and can merge it into master.

Thanks,
-David
