### PR TITLE
rememberPurchaseOfProduct: remembers currency correctly

### DIFF
--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -565,7 +565,7 @@ NSString *upgradePrice = [prices objectForKey:@"com.mycompany.upgrade"]
         int oldCount = [[MKStoreManager numberForKey:productPurchased] intValue];
         int newCount = oldCount + quantityPurchased;	
         
-        [MKStoreManager setObject:[NSNumber numberWithInt:newCount] forKey:productIdentifier];        
+        [MKStoreManager setObject:[NSNumber numberWithInt:newCount] forKey:productPurchased];        
     }
     else
     {


### PR DESCRIPTION
consumable was saving name of consumable feature instead of name of currency
