### PR TITLE
Cancel transactions if in-app is disabled

### DIFF
--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -470,6 +470,10 @@ static MKStoreManager* _sharedStoreManager;
 	{
     [self showAlertWithTitle:NSLocalizedString(@"In-App Purchasing disabled", @"")
                      message:NSLocalizedString(@"Check your parental control settings and try again later", @"")];
+		if (self.onTransactionCancelled)
+		{
+			self.onTransactionCancelled();
+		}
 	}
 }
 


### PR DESCRIPTION
The app using buyFeature:onComplete:onCancelled: method didn't know if in-app purchase may be disabled and neither of the blocks was called. If the app is displaying an activity indicator while purchasing is in progress waiting for either block, it was stuck. This patch fixes the issue.
