### PR TITLE
Add missing callback

### DIFF
--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -601,6 +601,8 @@ static MKStoreManager* _sharedStoreManager;
       [thisProduct verifyReceiptOnComplete:^
        {
          [self rememberPurchaseOfProduct:productIdentifier withReceipt:receiptData];
+         if(self.onTransactionCompleted)
+           self.onTransactionCompleted(productIdentifier, receiptData);                                         
        }
                                    onError:^(NSError* error)
        {


### PR DESCRIPTION
When verifying receipt for a consumable product is enabled, the completion block of MKStoreManager isn't triggered.
Not very sure if this is a correct fix though.
