### PR TITLE
Calling completion block when server receipt verified

### DIFF
--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -601,6 +601,9 @@ static MKStoreManager* _sharedStoreManager;
       [thisProduct verifyReceiptOnComplete:^
        {
          [self rememberPurchaseOfProduct:productIdentifier withReceipt:receiptData];
+         if(self.onTransactionCompleted)
+           self.onTransactionCompleted(productIdentifier, receiptData);
+		 
        }
                                    onError:^(NSError* error)
        {


### PR DESCRIPTION
In the completion block for verifyReceiptOnComplete the receipt details are stored by calling rememberPurchaseOfProduct

The problem I had was that on completion the completion block for the calling process of BuyFeature was never getting called.

I added

if(self.onTransactionCompleted)
               self.onTransactionCompleted(productIdentifier, receiptData);
