### PR TITLE
Dynamic FeatureIDs

### DIFF
--- a/MKStoreManager.h
+++ b/MKStoreManager.h
@@ -57,6 +57,10 @@
 
 // this is a static method, since it doesn't require the store manager to be initialized prior to calling
 + (BOOL) isFeaturePurchased:(NSString*) featureId; 
+
+// refresh product data with additional featureIds defined by the parameter
+- (void) requestProductData:(NSArray* (^)())loadIdentifierBlock;
+
 //returns a dictionary with all prices for identifiers
 - (NSMutableDictionary *)pricesDictionary;
 - (NSMutableArray*) purchasableObjectsDescription;

--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -246,11 +246,18 @@ static MKStoreManager* _sharedStoreManager;
 
 -(void) requestProductData
 {
+    [self requestProductData:nil];
+}
+
+-(void) requestProductData:(NSArray* (^)())loadIdentifierBlock
+{
   NSMutableArray *productsArray = [NSMutableArray array];
   NSArray *consumables = [[[self storeKitItems] objectForKey:@"Consumables"] allKeys];
   NSArray *nonConsumables = [[self storeKitItems] objectForKey:@"Non-Consumables"];
   NSArray *subscriptions = [[[self storeKitItems] objectForKey:@"Subscriptions"] allKeys];
-  
+
+  if(loadIdentifierBlock != nil) [productsArray addObjectsFromArray:loadIdentifierBlock()];
+
   [productsArray addObjectsFromArray:consumables];
   [productsArray addObjectsFromArray:nonConsumables];
   [productsArray addObjectsFromArray:subscriptions];
@@ -259,6 +266,7 @@ static MKStoreManager* _sharedStoreManager;
 	self.productsRequest.delegate = self;
 	[self.productsRequest start];
 }
+
 - (BOOL) removeAllKeychainData {
   NSMutableArray *productsArray = [NSMutableArray array];
   NSArray *consumables = [[[self storeKitItems] objectForKey:@"Consumables"] allKeys];


### PR DESCRIPTION
Under consideration of issue #50 and (6) of #86, I exposed `requestProductData` with an additional block as parameter. Using this block, additional featureIds, and therefore additional products, can be fetched at runtime.

Thank you for MKStoreKit, and I hope this helps!
