### PR TITLE
Fix to the removeAllKeychainData method. This commit permits to completely erase all consumable data left in the device.

### DIFF
--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -250,14 +250,26 @@ static MKStoreManager* _sharedStoreManager;
   
   NSMutableArray *productsArray = [NSMutableArray array];
   NSArray *consumables = [[[self storeKitItems] objectForKey:@"Consumables"] allKeys];
+  NSArray *consumableNames = [self allConsumableNames:consumables];
   NSArray *nonConsumables = [[self storeKitItems] objectForKey:@"Non-Consumables"];
   NSArray *subscriptions = [[[self storeKitItems] objectForKey:@"Subscriptions"] allKeys];
   
   [productsArray addObjectsFromArray:consumables];
+  [productsArray addObjectsFromArray:consumableNames];
   [productsArray addObjectsFromArray:nonConsumables];
   [productsArray addObjectsFromArray:subscriptions];
   
   return productsArray;
+}
+
++ (NSArray *)allConsumableNames:(NSArray *)consumables {
+    NSMutableSet *consumableNames = [[NSMutableSet alloc] initWithCapacity:0];
+    for (NSDictionary *consumable in consumables) {
+        NSString *name = [[consumables valueForKey:@"Name"] stringValue];
+        [consumableNames addObject:name];
+    }
+    
+    return [consumableNames allObjects];
 }
 
 - (BOOL) removeAllKeychainData {


### PR DESCRIPTION
Actually the removeAllKeychainData method will not delete the remaining count number of the single consumable items.
This happens because remaining consumable items are handled through a custom "name" as expressed in the plist configuration file, while the removeAllKeychainData method just deletes keychain data linked to the product identifier code. So, consumable data will never be completely erased.
Adding a list of the local consumable names to the allProducts solves the problem.
