### PR TITLE
Fix for issue # 103 - download of Apple hosted content

### DIFF
--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -565,6 +565,24 @@ static MKStoreManager* _sharedStoreManager;
   
   if(self.hostedContentDownloadStatusChangedHandler)
     self.hostedContentDownloadStatusChangedHandler(self.hostedContents);
+
+    // Finish any completed downloads
+    [hostedContents enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        SKDownload *download = obj;
+ 
+        switch (download.downloadState) {
+            case SKDownloadStateFinished:
+#ifndef NDEBUG
+                NSLog(@"Download finished: %@", [download description]);
+#endif
+                [self provideContent:download.transaction.payment.productIdentifier
+                          forReceipt:download.transaction.transactionReceipt
+                       hostedContent:[NSArray arrayWithObject:download]];
+                
+                [[SKPaymentQueue defaultQueue] finishTransaction:download.transaction];
+                break;
+        }
+    }];
 }
 #endif
 
@@ -738,6 +756,11 @@ static MKStoreManager* _sharedStoreManager;
   if([downloads count] > 0) {
     
     [[SKPaymentQueue defaultQueue] startDownloads:transaction.downloads];
+      // We don't have content yet, and we can't finish the transaction
+#ifndef NDEBUG
+      NSLog(@"Download(s) started: %@", [transaction description]);
+#endif
+      return;
   }
 #endif
   
@@ -760,6 +783,15 @@ static MKStoreManager* _sharedStoreManager;
   
 #ifdef __IPHONE_6_0
   downloads = transaction.downloads;
+    if([downloads count] > 0) {
+        
+        [[SKPaymentQueue defaultQueue] startDownloads:transaction.downloads];
+        // We don't have content yet, and we can't finish the transaction
+#ifndef NDEBUG
+        NSLog(@"Download(s) started: %@", [transaction description]);
+#endif
+        return;
+    }
 #endif
   
   [self provideContent: transaction.originalTransaction.payment.productIdentifier


### PR DESCRIPTION
Fix download of Apple hosted content. provideContent and finishTransaction cannot be called until content is actually downloaded.
