### PR TITLE
Add callback for product restore content available to restorePreviousTransactionsOnComplete

### DIFF
--- a/MKStoreManager.h
+++ b/MKStoreManager.h
@@ -74,7 +74,11 @@
         onCancelled:(void (^)(void)) cancelBlock;
 
 // use this method to restore a purchase
-- (void) restorePreviousTransactionsOnComplete:(void (^)(void)) completionBlock
+// - restoreCompletionBlock is called when the restore has been started; you are not required to do anything
+// - onComplete is called when content has been downloaded. Your content is available at download.contentURL, and you should
+//   copy and/or import it
+- (void) restorePreviousTransactionsOnComplete:(void (^)(void)) restoreCompletionBlock
+                                    onComplete:(void (^)(NSString* purchasedFeature, NSData*purchasedReceipt, NSArray* availableDownloads)) completionBlock
                                        onError:(void (^)(NSError* error)) errorBlock;
 
 // For consumable support

--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -207,10 +207,12 @@ static MKStoreManager* _sharedStoreManager;
            @"MKStoreKitConfigs.plist"]];
 }
 
-- (void) restorePreviousTransactionsOnComplete:(void (^)(void)) completionBlock
+- (void) restorePreviousTransactionsOnComplete:(void (^)(void)) restoreCompletionBlock
+                                                onComplete:(void (^)(NSString* purchasedFeature, NSData*purchasedReceipt, NSArray* availableDownloads)) completionBlock
                                        onError:(void (^)(NSError*)) errorBlock
 {
-  self.onRestoreCompleted = completionBlock;
+    self.onTransactionCompleted = completionBlock;
+    self.onRestoreCompleted = restoreCompletionBlock;
   self.onRestoreFailed = errorBlock;
   
 	[[SKPaymentQueue defaultQueue] restoreCompletedTransactions];


### PR DESCRIPTION
Add onComplete handler to restorePreviousTransactionsOnComplete. There are two stages to restore: the restore transaction succeeds, when restoreCompletionBlock is called, and any hosted content is downloaded, when completionBlock is called.
