### PR TITLE
check if configuration macroses already defined

### DIFF
--- a/MKStoreKitConfigs.h
+++ b/MKStoreKitConfigs.h
@@ -41,9 +41,19 @@
 #define kConsumableFeatureBId @"com.mycompany.myapp.005"
 #define FishBasket @"FishBasket"
 
-#define SERVER_PRODUCT_MODEL 0
-#define OWN_SERVER nil
-#define REVIEW_ALLOWED 0
+#ifndef SERVER_PRODUCT_MODEL
+    #define SERVER_PRODUCT_MODEL 0
+#endif
+
+#ifndef OWN_SERVER
+    #define OWN_SERVER nil
+#endif
+
+#ifndef REVIEW_ALLOWED
+    #define REVIEW_ALLOWED 0
+#endif
 
 #warning Shared Secret Missing Ignore this warning if you don't use auto-renewable subscriptions
-#define kSharedSecret @"<FILL IN YOUR SHARED SECRET HERE>"
+#ifndef kSharedSecret
+    #define kSharedSecret @"<FILL IN YOUR SHARED SECRET HERE>"
+#endif


### PR DESCRIPTION
It will allow users to define these settings outside the files which included in the MKStoreKit library. It especially makes sense for cocoapods installations.

In cocoapods installations these file will be added in Pods project and we don't have to edit it manually. It will be regenerated and edit only by cocoapods. 

And with this commit it becomes possible to define such macroses before importing MKStoreKit's headers.
