### PR TITLE
MKStoreKit restores not purchased items

### DIFF
--- a/MKStoreManager.h
+++ b/MKStoreManager.h
@@ -74,7 +74,7 @@
         onCancelled:(void (^)(void)) cancelBlock;
 
 // use this method to restore a purchase
-- (void) restorePreviousTransactionsOnComplete:(void (^)(void)) completionBlock
+- (void) restorePreviousTransactionsOnComplete:(void (^)(NSArray *purchasedItems)) completionBlock
                                        onError:(void (^)(NSError* error)) errorBlock;
 
 // For consumable support


### PR DESCRIPTION
### MKStoreKit restores not purchased items.
#### In-App Purchase Programming Guide says:

> "...if your application supports product types that must be restorable, you must include an interface that allows users to restore these purchases. This interface allows a user to add the product to other devices or, if the original device was wiped, to restore the transaction on the original device."
##### Steps to reproduce:

1.Create 'Restore' button with such implementation:

``` objective-c
[[MKStoreManager sharedManager] restorePreviousTransactionsOnComplete:^
{
    NSLog(@"Restore completed");
    // enable purchased functionality
} 
onError:^(NSError* error)
{
    NSLog(@"Restore failed");
}];
```

2.Use it for a 'clean' user (hasn't purchased any items before)

**Actual:** completion block is called and not purchased item will be restored. And you as developer will lost your money.
**Expected:** completion block should return array of already purchased items to be able restore only purchased once.
#### Problem place

Problem is hidden [here](https://github.com/MugunthKumar/MKStoreKit/blob/master/MKStoreManager.m#L744) - MKStoreKit doesn't do anything with response:

``` objective-c
- (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue
{
    [self restoreCompleted];
}
```

And for a 'clean' user **queue.transactions.count** wil be **0** but you as a developer doesn't know about this using MKStoreKit API.
#### Fix

I added post processing to return all previously purchased items to completion block.

HOWTO use it:

``` objective-c
[[MKStoreManager sharedManager] restorePreviousTransactionsOnComplete:^(NSArray *purchasedItems)
{
    NSLog(@"Restore completed");
    for (NSString *purchasedItemId in purchasedItems) 
    {
        if([purchasedItemId isEqualToString:DISABLE_ADS_FEATURE_ID])
        {
            // restore required functionality
        }
     }
} 
onError:^(NSError* error) 
{
    NSLog(@"Restore failed");
}];
```
