### PR TITLE
Fixed a compiler warning of deprecated uniqueIdentifier

### DIFF
--- a/VerificationController.m
+++ b/VerificationController.m
@@ -333,8 +333,12 @@ static VerificationController *singleton;
         }
 #endif
     } else {
-        // Pre iOS 6 
+        // Pre iOS 6
+        // Removes the compiler warning in the newest Xcode.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         NSString *localIdentifier           = [UIDevice currentDevice].uniqueIdentifier;
+#pragma clang diagnostic pop
         NSString *purchaseInfoUniqueId      = [purchaseInfoFromTransaction objectForKey:@"unique-identifier"];
 
         


### PR DESCRIPTION
Fixed a compiler warning of the deprecated call to uniqueIdentifier in iOS 6. It only switches off the diagnostics for this one line of code so isn't harmful for the rest of the project.
