### PR TITLE
Workaround Apple bug with nil productIdentifier

### DIFF
--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -605,6 +605,10 @@ static MKStoreManager* _sharedStoreManager;
             forReceipt:(NSData*) receiptData
          hostedContent:(NSArray*) hostedContent
 {
+  if (!productIdentifier) {
+    NSLog(@"productIdentifier is nil; Apple bug?");
+    return;
+  }
   MKSKSubscriptionProduct *subscriptionProduct = [self.subscriptionProducts objectForKey:productIdentifier];
   if(subscriptionProduct)
   {


### PR DESCRIPTION
A bunch of developers are reporting terrifying crash reports from Apple wherein Apple is queueing transactions with nil productIdentifier values. This causes MKStoreKit to try to set a nil key in NSUserDefaults, crashing the app.

The transaction is queued, so iOS replays the transaction at startup, crashing the app at startup, even after deleting and reinstalling the app.

http://stackoverflow.com/questions/19817130/following-in-app-purchase-app-crashing-on-startup-productidentifier-nil

I can reproduce this on iOS 7.0.4, but I can only repro it using the AppStore version of the app; I can never get the problem to occur in a private build. It seems like the only thing to do is to ignore these faulty transactions and hope that the user can issue a fresh request to restore transactions to access the purchased content. (I guess the user is screwed if the purchase was for consumable content!)
