### PR TITLE
Fixed int to NSUInteger for 64 bit arch

### DIFF
--- a/MKStoreManager.m
+++ b/MKStoreManager.m
@@ -276,7 +276,7 @@ static MKStoreManager* _sharedStoreManager;
 - (BOOL) removeAllKeychainData {
   
   NSMutableArray *productsArray = [MKStoreManager allProducts];
-  int itemCount = productsArray.count;
+  NSUInteger itemCount = productsArray.count;
   NSError *error;
   
   //loop through all the saved keychain data and remove it
@@ -466,7 +466,7 @@ static MKStoreManager* _sharedStoreManager;
   if ([SKPaymentQueue canMakePayments])
 	{
     NSArray *allIds = [self.purchasableObjects valueForKey:@"productIdentifier"];
-    int index = [allIds indexOfObject:productId];
+    NSUInteger index = [allIds indexOfObject:productId];
     
     if(index == NSNotFound) return;
     


### PR DESCRIPTION
Fixes severe bug on iPhone 5S and higher and iPad Air, caused by using int instead of NSUInteger. 
