### PR TITLE
Fixed: purchase status of non-consumable products is not persisted

### DIFF
--- a/MKStoreKit.m
+++ b/MKStoreKit.m
@@ -415,8 +415,8 @@ static NSDictionary *errorDictionary;
           NSNumber *currentConsumableCount = self.purchaseRecord[consumableId];
           consumableCount = @([consumableCount doubleValue] + [currentConsumableCount doubleValue]);
           self.purchaseRecord[consumableId] = consumableCount;
-          [self savePurchaseRecord];
         }
+        [self savePurchaseRecord];
         [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitProductPurchasedNotification
                                                             object:transaction.payment.productIdentifier];
       }


### PR DESCRIPTION
With the previous implementation, the status of only products belonging to the group "Consumable" is persisted in a file. With my suggestion, the status of products belonging to "Others" is also persisted.