### PR TITLE
Deferred Purchases and Mac OS X Compatibility

### DIFF
--- a/MKStoreKit.h
+++ b/MKStoreKit.h
@@ -36,14 +36,25 @@
 //  A note on redistribution
 //	if you are re-publishing after editing, please retain the above copyright notices
 
-#import <Foundation/Foundation.h>
+#if TARGET_OS_IPHONE
+    #import <Foundation/Foundation.h>
 
-#if ! __has_feature(objc_arc)
-#error MKStoreKit is ARC only. Either turn on ARC for the project or use -fobjc-arc flag
+    #ifndef __IPHONE_7_0
+        #error "MKStoreKit is only supported on iOS 7 or later."
+    #endif
+
+#else
+    #import <Foundation/Foundation.h>
+    #import <Cocoa/Cocoa.h>
+
+    #ifndef __MAC_10_10
+        #error "MKStoreKit is only supported on OS X 10.10 or later."
+    #endif
+
 #endif
 
-#ifndef __IPHONE_7_0
-#error "MKStoreKit is supported only on iOS 7 or later."
+#if ! __has_feature(objc_arc)
+    #error MKStoreKit is ARC only. Either turn on ARC for the project or use -fobjc-arc flag
 #endif
 
 /*!
@@ -70,7 +81,7 @@ extern NSString *const kMKStoreKitProductPurchaseFailedNotification;
  *   to be notified of the completed or failed purchase.
  *  @availability iOS 8.0 or later
  */
-extern NSString *const kMKStoreKitProductPurchaseDeferredNotification NS_AVAILABLE_IOS(8_0);
+extern NSString *const kMKStoreKitProductPurchaseDeferredNotification NS_AVAILABLE(10_10, 8_0);
 
 /*!
  *  @abstract This notification is posted when MKStoreKit completes restoring purchases
@@ -119,7 +130,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @discussion
  *	Use this to access the only object of MKStoreKit
  */
-+ (MKStoreKit*) sharedKit;
++ (MKStoreKit *)sharedKit;
 
 /*!
  *  @abstract Initializes MKStoreKit singleton by making the product request using StoreKit's SKProductRequest
@@ -134,7 +145,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -availableProducts
  */
-- (void) startProductRequest;
+- (void)startProductRequest;
 
 /*!
  *  @abstract Restores In App Purchases made on other devices
@@ -142,7 +153,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @discussion
  *	This method restores your user's In App Purchases made on other devices.
  */
-- (void) restorePurchases;
+- (void)restorePurchases;
 
 /*!
  *  @abstract Initiates payment request for a In App Purchasable Product
@@ -156,7 +167,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  -isProductPurchased
  *  -expiryDateForProduct
  */
-- (void) initiatePaymentRequestForProductWithIdentifier:(NSString*) productId;
+- (void)initiatePaymentRequestForProductWithIdentifier:(NSString *)productId;
 
 /*!
  *  @abstract Checks whether the product identified by the given productId is purchased previously
@@ -169,7 +180,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -expiryDateForProduct
  */
-- (BOOL) isProductPurchased:(NSString*) productId;
+- (BOOL)isProductPurchased:(NSString *)productId;
 
 /*!
  *  @abstract Checks the expiry date for the product identified by the given productId
@@ -188,7 +199,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -isProductPurchased
  */
-- (NSDate*) expiryDateForProduct:(NSString*) productId;
+- (NSDate *)expiryDateForProduct:(NSString *)productId;
 
 /*!
  *  @abstract This method returns the available credits (managed by MKStoreKit) for a given consumable
@@ -202,7 +213,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -isProductPurchased
  */
-- (NSNumber*) availableCreditsForConsumable:(NSString*) consumableID;
+- (NSNumber *)availableCreditsForConsumable:(NSString *)consumableID;
 
 /*!
  *  @abstract This method updates the available credits (managed by MKStoreKit) for a given consumable
@@ -216,7 +227,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -isProductPurchased
  */
-- (NSNumber*) consumeCredits:(NSNumber*) creditCountToConsume identifiedByConsumableIdentifier:(NSString*) consumableId;
+- (NSNumber *)consumeCredits:(NSNumber *)creditCountToConsume identifiedByConsumableIdentifier:(NSString *)consumableId;
 
 /*!
  *  @abstract This method sets the default credits (managed by MKStoreKit) for a given consumable
@@ -230,7 +241,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -isProductPurchased
  */
-- (void) setDefaultCredits:(NSNumber*) creditCount forConsumableIdentifier:(NSString*) consumableId;
+- (void)setDefaultCredits:(NSNumber *)creditCount forConsumableIdentifier:(NSString *)consumableId;
 
 
 @end

--- a/MKStoreKit.h
+++ b/MKStoreKit.h
@@ -57,9 +57,20 @@ extern NSString *const kMKStoreKitProductsAvailableNotification;
 extern NSString *const kMKStoreKitProductPurchasedNotification;
 
 /*!
- *  @abstract This notification is posted when MKStoreKit failes to complete the purchase of a product
+ *  @abstract This notification is posted when MKStoreKit fails to complete the purchase of a product
  */
 extern NSString *const kMKStoreKitProductPurchaseFailedNotification;
+
+/*!
+ *  @abstract This notification is posted when MKStoreKit has a purchase deferred for approval
+ *  @discussion
+ *  This occurs when a device has parental controls for in-App Purchases enabled.
+ *   iOS will present a prompt for parental approval, either on the current device or
+ *   on the parent's device. Update your UI to reflect the deferred status, and wait
+ *   to be notified of the completed or failed purchase.
+ *  @availability iOS 8.0 or later
+ */
+extern NSString *const kMKStoreKitProductPurchaseDeferredNotification NS_AVAILABLE_IOS(8_0);
 
 /*!
  *  @abstract This notification is posted when MKStoreKit completes restoring purchases
@@ -117,13 +128,13 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *	This method should be called in your application:didFinishLaunchingWithOptions: method
  *  If this method fails, MKStoreKit will not work
  *  Most common reason for this method to fail is Internet connection being offline
- *  It's your responsibility to call startProductRequest if the Internet connection comes online 
+ *  It's your responsibility to call startProductRequest if the Internet connection comes online
  *  and the previous call to startProductRequest failed (availableProducts.count == 0).
  *
  *  @seealso
  *  -availableProducts
  */
--(void) startProductRequest;
+- (void) startProductRequest;
 
 /*!
  *  @abstract Restores In App Purchases made on other devices
@@ -131,7 +142,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @discussion
  *	This method restores your user's In App Purchases made on other devices.
  */
--(void) restorePurchases;
+- (void) restorePurchases;
 
 /*!
  *  @abstract Initiates payment request for a In App Purchasable Product
@@ -145,7 +156,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  -isProductPurchased
  *  -expiryDateForProduct
  */
--(void) initiatePaymentRequestForProductWithIdentifier:(NSString*) productId;
+- (void) initiatePaymentRequestForProductWithIdentifier:(NSString*) productId;
 
 /*!
  *  @abstract Checks whether the product identified by the given productId is purchased previously
@@ -158,7 +169,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -expiryDateForProduct
  */
--(BOOL) isProductPurchased:(NSString*) productId;
+- (BOOL) isProductPurchased:(NSString*) productId;
 
 /*!
  *  @abstract Checks the expiry date for the product identified by the given productId
@@ -177,7 +188,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -isProductPurchased
  */
--(NSDate*) expiryDateForProduct:(NSString*) productId;
+- (NSDate*) expiryDateForProduct:(NSString*) productId;
 
 /*!
  *  @abstract This method returns the available credits (managed by MKStoreKit) for a given consumable
@@ -191,7 +202,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -isProductPurchased
  */
--(NSNumber*) availableCreditsForConsumable:(NSString*) consumableID;
+- (NSNumber*) availableCreditsForConsumable:(NSString*) consumableID;
 
 /*!
  *  @abstract This method updates the available credits (managed by MKStoreKit) for a given consumable
@@ -205,7 +216,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -isProductPurchased
  */
--(NSNumber*) consumeCredits:(NSNumber*) creditCountToConsume identifiedByConsumableIdentifier:(NSString*) consumableId;
+- (NSNumber*) consumeCredits:(NSNumber*) creditCountToConsume identifiedByConsumableIdentifier:(NSString*) consumableId;
 
 /*!
  *  @abstract This method sets the default credits (managed by MKStoreKit) for a given consumable
@@ -219,7 +230,7 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  @seealso
  *  -isProductPurchased
  */
--(void) setDefaultCredits:(NSNumber*) creditCount forConsumableIdentifier:(NSString*) consumableId;
+- (void) setDefaultCredits:(NSNumber*) creditCount forConsumableIdentifier:(NSString*) consumableId;
 
 
 @end

--- a/MKStoreKit.m
+++ b/MKStoreKit.m
@@ -42,6 +42,7 @@
 NSString *const kMKStoreKitProductsAvailableNotification = @"com.mugunthkumar.mkstorekit.productsavailable";
 NSString *const kMKStoreKitProductPurchasedNotification = @"com.mugunthkumar.mkstorekit.productspurchased";
 NSString *const kMKStoreKitProductPurchaseFailedNotification = @"com.mugunthkumar.mkstorekit.productspurchasefailed";
+NSString *const kMKStoreKitProductPurchaseDeferredNotification = @"com.mugunthkumar.mkstorekit.productspurchasedeferred";
 NSString *const kMKStoreKitRestoredPurchasesNotification = @"com.mugunthkumar.mkstorekit.restoredpurchases";
 NSString *const kMKStoreKitRestoringPurchasesFailedNotification = @"com.mugunthkumar.mkstorekit.failedrestoringpurchases";
 NSString *const kMKStoreKitReceiptValidationFailedNotification = @"com.mugunthkumar.mkstorekit.failedvalidatingreceipts";
@@ -61,392 +62,368 @@ static NSDictionary *errorDictionary;
 #pragma mark -
 #pragma mark Singleton Methods
 
-+ (MKStoreKit*)sharedKit {
-  
-  static MKStoreKit *_sharedKit;
-  if(!_sharedKit) {
-    static dispatch_once_t oncePredicate;
-    dispatch_once(&oncePredicate, ^{
-      _sharedKit = [[super allocWithZone:nil] init];
-      [[SKPaymentQueue defaultQueue] addTransactionObserver:_sharedKit];
-      [_sharedKit restorePurchaseRecord];
-      [[NSNotificationCenter defaultCenter] addObserver:_sharedKit
-                                               selector:@selector(savePurchaseRecord)
-                                                   name:UIApplicationDidEnterBackgroundNotification object:nil];
-      
-      [_sharedKit startValidatingReceiptsAndUpdateLocalStore];
-    });
-		}
-  
-		return _sharedKit;
++ (MKStoreKit *)sharedKit {
+    static MKStoreKit *_sharedKit;
+    if(!_sharedKit) {
+        static dispatch_once_t oncePredicate;
+        dispatch_once(&oncePredicate, ^{
+            _sharedKit = [[super allocWithZone:nil] init];
+            [[SKPaymentQueue defaultQueue] addTransactionObserver:_sharedKit];
+            [_sharedKit restorePurchaseRecord];
+            [[NSNotificationCenter defaultCenter] addObserver:_sharedKit
+                                                     selector:@selector(savePurchaseRecord)
+                                                         name:UIApplicationDidEnterBackgroundNotification object:nil];
+            
+            [_sharedKit startValidatingReceiptsAndUpdateLocalStore];
+        });
+    }
+    
+    return _sharedKit;
 }
 
 + (id)allocWithZone:(NSZone *)zone {
-  
-  return [self sharedKit];
+    
+    return [self sharedKit];
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-  
-  return self;
+    
+    return self;
 }
 
 #pragma mark -
 #pragma mark Initializer
 
-+(void) initialize {
-  
-  errorDictionary = @{@(21000) : @"The App Store could not read the JSON object you provided.",
-                      @(21002) : @"The data in the receipt-data property was malformed or missing.",
-                      @(21003) : @"The receipt could not be authenticated.",
-                      @(21004) : @"The shared secret you provided does not match the shared secret on file for your accunt.",
-                      @(21005) : @"The receipt server is not currently available.",
-                      @(21006) : @"This receipt is valid but the subscription has expired.",
-                      @(21007) : @"This receipt is from the test environment.",
-                      @(21008) : @"This receipt is from the production environment."};
++ (void)initialize {
+    errorDictionary = @{@(21000) : @"The App Store could not read the JSON object you provided.",
+                        @(21002) : @"The data in the receipt-data property was malformed or missing.",
+                        @(21003) : @"The receipt could not be authenticated.",
+                        @(21004) : @"The shared secret you provided does not match the shared secret on file for your accunt.",
+                        @(21005) : @"The receipt server is not currently available.",
+                        @(21006) : @"This receipt is valid but the subscription has expired.",
+                        @(21007) : @"This receipt is from the test environment.",
+                        @(21008) : @"This receipt is from the production environment."};
 }
 
 #pragma mark -
 #pragma mark Helpers
 
-+(NSDictionary*) configs {
-  
-  return [NSDictionary dictionaryWithContentsOfFile:
-          [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:
-           @"MKStoreKitConfigs.plist"]];
++ (NSDictionary *)configs {
+    return [NSDictionary dictionaryWithContentsOfFile:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"MKStoreKitConfigs.plist"]];
 }
 
 
 #pragma mark -
 #pragma mark Store File Management
 
--(NSString*) purchaseRecordFilePath {
-  
-  NSString *documentDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
-                                                                    NSUserDomainMask, YES).firstObject;
-  return [documentDirectory stringByAppendingPathComponent:@"purchaserecord.plist"];
+- (NSString *)purchaseRecordFilePath {
+    NSString *documentDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+    return [documentDirectory stringByAppendingPathComponent:@"purchaserecord.plist"];
 }
 
--(void) restorePurchaseRecord {
-  
-  self.purchaseRecord = (NSMutableDictionary*) [[NSKeyedUnarchiver unarchiveObjectWithFile:
-                                                 [self purchaseRecordFilePath]] mutableCopy];
-  if(self.purchaseRecord == nil) {
-    self.purchaseRecord = [NSMutableDictionary dictionary];
-  }
+- (void)restorePurchaseRecord {
+    self.purchaseRecord = (NSMutableDictionary *)[[NSKeyedUnarchiver unarchiveObjectWithFile:[self purchaseRecordFilePath]] mutableCopy];
+    if (self.purchaseRecord == nil) {
+        self.purchaseRecord = [NSMutableDictionary dictionary];
+    }
 }
 
--(void) savePurchaseRecord {
-  
-  NSError *error = nil;
-  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self.purchaseRecord];
-  BOOL success = [data writeToFile:[self purchaseRecordFilePath]
-                           options:NSDataWritingAtomic | NSDataWritingFileProtectionComplete
-                             error:&error];
-  
-  if(!success) {
+- (void)savePurchaseRecord {
+    NSError *error = nil;
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self.purchaseRecord];
+    BOOL success = [data writeToFile:[self purchaseRecordFilePath] options:NSDataWritingAtomic | NSDataWritingFileProtectionComplete error:&error];
     
-    NSLog(@"Failed to remember data record");
-  }
-  NSLog(@"%@", self.purchaseRecord);
+    if (!success) {
+        NSLog(@"Failed to remember data record");
+    }
+    
+    NSLog(@"%@", self.purchaseRecord);
 }
 
 #pragma mark -
 #pragma mark Feature Management
 
--(BOOL) isProductPurchased:(NSString*) productId {
-  
-  return [self.purchaseRecord.allKeys containsObject:productId];
+- (BOOL)isProductPurchased:(NSString *)productId {
+    return [self.purchaseRecord.allKeys containsObject:productId];
 }
 
--(NSDate*) expiryDateForProduct:(NSString*) productId {
-  
-  NSNumber *expiresDateMs = self.purchaseRecord[productId];
-  return [NSDate dateWithTimeIntervalSince1970:[expiresDateMs doubleValue]];
+- (NSDate *)expiryDateForProduct:(NSString *)productId {
+    NSNumber *expiresDateMs = self.purchaseRecord[productId];
+    return [NSDate dateWithTimeIntervalSince1970:[expiresDateMs doubleValue]];
 }
 
--(NSNumber*) availableCreditsForConsumable:(NSString*) consumableId {
-  
-  return self.purchaseRecord[consumableId];
+- (NSNumber *)availableCreditsForConsumable:(NSString *)consumableId {
+    return self.purchaseRecord[consumableId];
 }
 
--(NSNumber*) consumeCredits:(NSNumber*) creditCountToConsume identifiedByConsumableIdentifier:(NSString*) consumableId {
-  
-  NSNumber *currentConsumableCount = self.purchaseRecord[consumableId];
-  currentConsumableCount = @([currentConsumableCount doubleValue] - [creditCountToConsume doubleValue]);
-  self.purchaseRecord[consumableId] = currentConsumableCount;
-  [self savePurchaseRecord];
-  return currentConsumableCount;
-}
-
--(void) setDefaultCredits:(NSNumber*) creditCount forConsumableIdentifier:(NSString*) consumableId {
-  
-  if(self.purchaseRecord[consumableId] == nil) {
-    
-    self.purchaseRecord[consumableId] = creditCount;
+- (NSNumber *)consumeCredits:(NSNumber *)creditCountToConsume identifiedByConsumableIdentifier:(NSString *)consumableId {
+    NSNumber *currentConsumableCount = self.purchaseRecord[consumableId];
+    currentConsumableCount = @([currentConsumableCount doubleValue] - [creditCountToConsume doubleValue]);
+    self.purchaseRecord[consumableId] = currentConsumableCount;
     [self savePurchaseRecord];
-  }
+    return currentConsumableCount;
+}
+
+- (void)setDefaultCredits:(NSNumber *)creditCount forConsumableIdentifier:(NSString *)consumableId {
+    
+    if(self.purchaseRecord[consumableId] == nil) {
+        
+        self.purchaseRecord[consumableId] = creditCount;
+        [self savePurchaseRecord];
+    }
 }
 
 #pragma mark -
 #pragma mark Start requesting for available in app purchases
 
--(void) startProductRequest {
-  
-  NSMutableArray *productsArray = [NSMutableArray array];
-  NSArray *consumables = [[MKStoreKit configs][@"Consumables"] allKeys];
-  NSArray *others = [MKStoreKit configs][@"Others"];
-  
-  [productsArray addObjectsFromArray:consumables];
-  [productsArray addObjectsFromArray:others];
-  
-  SKProductsRequest *productsRequest = [[SKProductsRequest alloc]
-                                        initWithProductIdentifiers:[NSSet setWithArray:productsArray]];
-  productsRequest.delegate = self;
-  [productsRequest start];
+- (void)startProductRequest {
+    NSMutableArray *productsArray = [NSMutableArray array];
+    NSArray *consumables = [[MKStoreKit configs][@"Consumables"] allKeys];
+    NSArray *others = [MKStoreKit configs][@"Others"];
+    
+    [productsArray addObjectsFromArray:consumables];
+    [productsArray addObjectsFromArray:others];
+    
+    SKProductsRequest *productsRequest = [[SKProductsRequest alloc]
+                                          initWithProductIdentifiers:[NSSet setWithArray:productsArray]];
+    productsRequest.delegate = self;
+    [productsRequest start];
 }
 
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {
-  
-  if(response.invalidProductIdentifiers.count > 0) {
-    NSLog(@"Invalid Product IDs: %@", response.invalidProductIdentifiers);
-  }
-  
-  self.availableProducts = response.products;
-  [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitProductsAvailableNotification
-                                                      object:self.availableProducts];
+    if (response.invalidProductIdentifiers.count > 0) {
+        NSLog(@"Invalid Product IDs: %@", response.invalidProductIdentifiers);
+    }
+    
+    self.availableProducts = response.products;
+    [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitProductsAvailableNotification
+                                                        object:self.availableProducts];
 }
 
 - (void)request:(SKRequest *)request didFailWithError:(NSError *)error {
-  
-  NSLog(@"Product request failed with error: %@", error);
+    NSLog(@"Product request failed with error: %@", error);
 }
 
 #pragma mark -
 #pragma mark Restore Purchases
 
--(void) restorePurchases {
-  
-  [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
+- (void)restorePurchases {
+    [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
 }
 
 - (void)paymentQueue:(SKPaymentQueue *)queue restoreCompletedTransactionsFailedWithError:(NSError *)error {
-  
-  [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitRestoringPurchasesFailedNotification
-                                                      object:error];
+    [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitRestoringPurchasesFailedNotification object:error];
 }
 
 - (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue {
-  
-  [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitRestoredPurchasesNotification
-                                                      object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitRestoredPurchasesNotification object:nil];
 }
 
 #pragma mark -
 #pragma mark Initiate a Purchase
 
--(void) initiatePaymentRequestForProductWithIdentifier:(NSString*) productId {
-  
-  if(!self.availableProducts) {
-    // FIX ME
-    // Initializer might be running or internet might not be available
-    NSLog(@"No products are available. Did you initialize MKStoreKit by calling [[MKStoreManager sharedManager] startProductRequest]");
-  }
-  if(![SKPaymentQueue canMakePayments]) {
-    
-    [[[UIAlertView alloc] initWithTitle:NSLocalizedString(@"In App Purchasing Disabled", @"")
-                                message:NSLocalizedString(@"Check your parental control settings and try again later", @"")
-                               delegate:self
-                      cancelButtonTitle:NSLocalizedString(@"OK", @"")
-                      otherButtonTitles: nil] show];
-    
-    return;
-  }
-  [self.availableProducts enumerateObjectsUsingBlock:^(SKProduct *thisProduct, NSUInteger idx, BOOL *stop) {
-    
-    if([thisProduct.productIdentifier isEqualToString:productId]) {
-      
-      *stop = YES;
-      SKPayment *payment = [SKPayment paymentWithProduct:thisProduct];
-      [[SKPaymentQueue defaultQueue] addPayment:payment];
+- (void)initiatePaymentRequestForProductWithIdentifier:(NSString *)productId {
+    if (!self.availableProducts) {
+        // TODO: FIX ME
+        // Initializer might be running or internet might not be available
+        NSLog(@"No products are available. Did you initialize MKStoreKit by calling [[MKStoreManager sharedManager] startProductRequest]?");
     }
-  }];
+    
+    if (![SKPaymentQueue canMakePayments]) {
+        [[[UIAlertView alloc] initWithTitle:NSLocalizedString(@"In App Purchasing Disabled", @"")
+                                    message:NSLocalizedString(@"Check your parental control settings and try again later", @"")
+                                   delegate:self
+                          cancelButtonTitle:NSLocalizedString(@"Okay", @"")
+                          otherButtonTitles:nil] show];
+        
+        return;
+    }
+    
+    [self.availableProducts enumerateObjectsUsingBlock:^(SKProduct *thisProduct, NSUInteger idx, BOOL *stop) {
+        if ([thisProduct.productIdentifier isEqualToString:productId]) {
+            *stop = YES;
+            SKPayment *payment = [SKPayment paymentWithProduct:thisProduct];
+            [[SKPaymentQueue defaultQueue] addPayment:payment];
+        }
+    }];
 }
 
 #pragma mark -
 #pragma mark Receipt validation
 
--(void) startValidatingAppStoreReceiptWithCompletionHandler:(void (^)(NSArray *receipts, NSError *error)) completionHandler {
-  
-  NSData *receiptData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL]];
-  if(!receiptData) {
-    completionHandler(nil, nil);
-    return;
-  }
-  NSError *error;
-  NSMutableDictionary *requestContents = [NSMutableDictionary dictionaryWithObject:
-                                          [receiptData base64EncodedStringWithOptions:0] forKey:@"receipt-data"];
-  NSString *sharedSecret = [MKStoreKit configs][@"SharedSecret"];
-  if(sharedSecret) requestContents[@"password"] = sharedSecret;
-  
-  NSData *requestData = [NSJSONSerialization dataWithJSONObject:requestContents
-                                                        options:0
-                                                          error:&error];
-  
+- (void)startValidatingAppStoreReceiptWithCompletionHandler:(void (^)(NSArray *receipts, NSError *error)) completionHandler {
+    NSData *receiptData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL]];
+    if (!receiptData) {
+        completionHandler(nil, nil);
+        return;
+    }
+    
+    NSError *error;
+    NSMutableDictionary *requestContents = [NSMutableDictionary dictionaryWithObject:
+                                            [receiptData base64EncodedStringWithOptions:0] forKey:@"receipt-data"];
+    NSString *sharedSecret = [MKStoreKit configs][@"SharedSecret"];
+    if (sharedSecret) requestContents[@"password"] = sharedSecret;
+    
+    NSData *requestData = [NSJSONSerialization dataWithJSONObject:requestContents
+                                                          options:0
+                                                            error:&error];
+    
 #ifdef DEBUG
-  NSMutableURLRequest *storeRequest = [NSMutableURLRequest requestWithURL:
-                                       [NSURL URLWithString:kSandboxServer]];
+    NSMutableURLRequest *storeRequest = [NSMutableURLRequest requestWithURL:
+                                         [NSURL URLWithString:kSandboxServer]];
 #else
-  NSMutableURLRequest *storeRequest = [NSMutableURLRequest requestWithURL:
-                                       [NSURL URLWithString:kLiveServer]];
+    NSMutableURLRequest *storeRequest = [NSMutableURLRequest requestWithURL:
+                                         [NSURL URLWithString:kLiveServer]];
 #endif
-  
-  [storeRequest setHTTPMethod:@"POST"];
-  [storeRequest setHTTPBody:requestData];
-  
-  NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
-  
-  [[session dataTaskWithRequest:storeRequest
-              completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                
-                if(!error) {
-                  NSDictionary *jsonResponse = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
-                  NSInteger status = [jsonResponse[@"status"] integerValue];
-                  if(status != 0) {
-                    NSError *error = [NSError errorWithDomain:@"com.mugunthkumar.mkstorekit"
-                                                         code:status
-                                                     userInfo:@{NSLocalizedDescriptionKey : errorDictionary[@(status)]}];
-                    completionHandler(nil, error);
-                  } else {
+    
+    [storeRequest setHTTPMethod:@"POST"];
+    [storeRequest setHTTPBody:requestData];
+    
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    
+    [[session dataTaskWithRequest:storeRequest
+                completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                     
-                    NSMutableArray *receipts = [jsonResponse[@"latest_receipt_info"] mutableCopy];
-                    NSArray *inAppReceipts = jsonResponse[@"receipt"][@"in_app"];
-                    [receipts addObjectsFromArray:inAppReceipts];
-                    completionHandler(receipts, nil);
-                  }
-                } else {
-                  completionHandler(nil, error);
-                }
-              }] resume];
+                    if (!error) {
+                        NSDictionary *jsonResponse = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+                        NSInteger status = [jsonResponse[@"status"] integerValue];
+                        if(status != 0) {
+                            NSError *error = [NSError errorWithDomain:@"com.mugunthkumar.mkstorekit"
+                                                                 code:status
+                                                             userInfo:@{NSLocalizedDescriptionKey : errorDictionary[@(status)]}];
+                            completionHandler(nil, error);
+                        } else {
+                            
+                            NSMutableArray *receipts = [jsonResponse[@"latest_receipt_info"] mutableCopy];
+                            NSArray *inAppReceipts = jsonResponse[@"receipt"][@"in_app"];
+                            [receipts addObjectsFromArray:inAppReceipts];
+                            completionHandler(receipts, nil);
+                        }
+                    } else {
+                        completionHandler(nil, error);
+                    }
+                }] resume];
 }
 
--(void) startValidatingReceiptsAndUpdateLocalStore {
-  
-  [self startValidatingAppStoreReceiptWithCompletionHandler:^(NSArray *receipts, NSError *error) {
+- (void)startValidatingReceiptsAndUpdateLocalStore {
     
-    if(error) {
-      
-      NSLog(@"Receipt validation failed with error: %@", error);
-      [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitReceiptValidationFailedNotification
-                                                          object:error];
-    } else {
-      
-      __block BOOL purchaseRecordDirty = NO;
-      [receipts enumerateObjectsUsingBlock:^(NSDictionary *receiptDictionary, NSUInteger idx, BOOL *stop) {
+    [self startValidatingAppStoreReceiptWithCompletionHandler:^(NSArray *receipts, NSError *error) {
         
-        NSString *productIdentifier = receiptDictionary[@"product_id"];
-        NSNumber *expiresDateMs = receiptDictionary[@"expires_date_ms"];
-        if(expiresDateMs && ![expiresDateMs isKindOfClass: [NSNull class]]) {
-          NSNumber *previouslyStoredExpiresDateMs = self.purchaseRecord[productIdentifier];
-          if([expiresDateMs doubleValue] > [previouslyStoredExpiresDateMs doubleValue]) {
-            self.purchaseRecord[productIdentifier] = expiresDateMs;
-            purchaseRecordDirty = YES;
-          }
-        }
-      }];
-      
-      if(purchaseRecordDirty) [self savePurchaseRecord];
-      
-      [self.purchaseRecord enumerateKeysAndObjectsUsingBlock:^(NSString *productIdentifier, NSNumber *expiresDateMs, BOOL *stop) {
-        
-        if(![expiresDateMs isKindOfClass: [NSNull class]]) {
-          
-          if([[NSDate date] timeIntervalSince1970] > [expiresDateMs doubleValue]) {
+        if (error) {
             
-            [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitSubscriptionExpiredNotification
-                                                                object:productIdentifier];
-          }
+            NSLog(@"Receipt validation failed with error: %@", error);
+            [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitReceiptValidationFailedNotification
+                                                                object:error];
+        } else {
+            
+            __block BOOL purchaseRecordDirty = NO;
+            [receipts enumerateObjectsUsingBlock:^(NSDictionary *receiptDictionary, NSUInteger idx, BOOL *stop) {
+                
+                NSString *productIdentifier = receiptDictionary[@"product_id"];
+                NSNumber *expiresDateMs = receiptDictionary[@"expires_date_ms"];
+                if(expiresDateMs && ![expiresDateMs isKindOfClass: [NSNull class]]) {
+                    NSNumber *previouslyStoredExpiresDateMs = self.purchaseRecord[productIdentifier];
+                    if([expiresDateMs doubleValue] > [previouslyStoredExpiresDateMs doubleValue]) {
+                        self.purchaseRecord[productIdentifier] = expiresDateMs;
+                        purchaseRecordDirty = YES;
+                    }
+                }
+            }];
+            
+            if (purchaseRecordDirty) [self savePurchaseRecord];
+            
+            [self.purchaseRecord enumerateKeysAndObjectsUsingBlock:^(NSString *productIdentifier, NSNumber *expiresDateMs, BOOL *stop) {
+                
+                if(![expiresDateMs isKindOfClass: [NSNull class]]) {
+                    
+                    if([[NSDate date] timeIntervalSince1970] > [expiresDateMs doubleValue]) {
+                        
+                        [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitSubscriptionExpiredNotification
+                                                                            object:productIdentifier];
+                    }
+                }
+            }];
         }
-      }];
-    }
-  }];
+    }];
 }
 
 #pragma mark -
 #pragma mark Transaction Observers
 
-//FIX ME
--(void) paymentQueue:(SKPaymentQueue *)queue updatedDownloads:(NSArray *)downloads {
-  
-  [downloads enumerateObjectsUsingBlock:^(SKDownload *thisDownload, NSUInteger idx, BOOL *stop) {
-    
-    switch (thisDownload.downloadState) {
-      case SKDownloadStateActive:
-        break;
-      case SKDownloadStateFinished:
-        break;
-      default:
-        break;
-    }
-  }];
+// TODO: FIX ME
+- (void)paymentQueue:(SKPaymentQueue *)queue updatedDownloads:(NSArray *)downloads {
+    [downloads enumerateObjectsUsingBlock:^(SKDownload *thisDownload, NSUInteger idx, BOOL *stop) {
+        switch (thisDownload.downloadState) {
+            case SKDownloadStateActive:
+                break;
+            case SKDownloadStateFinished:
+                break;
+            default:
+                break;
+        }
+    }];
 }
 
 - (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions {
-  
-  for (SKPaymentTransaction *transaction in transactions) {
-    switch (transaction.transactionState) {
-        
-      case SKPaymentTransactionStatePurchasing:
-        break;
-        
-      case SKPaymentTransactionStateDeferred:
-        // FIX ME
-        break;
-        
-      case SKPaymentTransactionStateFailed:
-        NSLog(@"Transaction Failed with error: %@", transaction.error);
-        [queue finishTransaction:transaction];
-        break;
-        
-      case SKPaymentTransactionStatePurchased:
-      case SKPaymentTransactionStateRestored: {
-        
-        if(transaction.downloads.count > 0) {
-          [queue startDownloads:transaction.downloads];
+    for (SKPaymentTransaction *transaction in transactions) {
+        switch (transaction.transactionState) {
+                
+            case SKPaymentTransactionStatePurchasing:
+                break;
+                
+            case SKPaymentTransactionStateDeferred:
+                [self deferredTransaction:transaction inQueue:queue];
+                break;
+                
+            case SKPaymentTransactionStateFailed:
+                [self failedTransaction:transaction inQueue:queue];
+                break;
+                
+            case SKPaymentTransactionStatePurchased:
+            case SKPaymentTransactionStateRestored: {
+                
+                if (transaction.downloads.count > 0) {
+                    [queue startDownloads:transaction.downloads];
+                }
+                
+                [queue finishTransaction:transaction];
+                
+                NSDictionary *availableConsumables = [MKStoreKit configs][@"Consumables"];
+                NSArray *consumables = [availableConsumables allKeys];
+                if ([consumables containsObject:transaction.payment.productIdentifier]) {
+                    
+                    NSDictionary *thisConsumable = availableConsumables[transaction.payment.productIdentifier];
+                    NSString *consumableId = thisConsumable[@"ConsumableId"];
+                    NSNumber *consumableCount = thisConsumable[@"ConsumableCount"];
+                    NSNumber *currentConsumableCount = self.purchaseRecord[consumableId];
+                    consumableCount = @([consumableCount doubleValue] + [currentConsumableCount doubleValue]);
+                    self.purchaseRecord[consumableId] = consumableCount;
+                } else {
+                    // non-consumable or subscriptions
+                    // subscriptions will eventually contain the expiry date after the receipt is validated during the next run
+                    self.purchaseRecord[transaction.payment.productIdentifier] = [NSNull null];
+                }
+                
+                [self savePurchaseRecord];
+                [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitProductPurchasedNotification
+                                                                    object:transaction.payment.productIdentifier];
+            }
+                break;
         }
-        
-        [queue finishTransaction:transaction];
-        
-        NSDictionary *availableConsumables = [MKStoreKit configs][@"Consumables"];
-        NSArray *consumables = [availableConsumables allKeys];
-        if([consumables containsObject:transaction.payment.productIdentifier]) {
-          
-          NSDictionary *thisConsumable = availableConsumables[transaction.payment.productIdentifier];
-          NSString *consumableId = thisConsumable[@"ConsumableId"];
-          NSNumber *consumableCount = thisConsumable[@"ConsumableCount"];
-          NSNumber *currentConsumableCount = self.purchaseRecord[consumableId];
-          consumableCount = @([consumableCount doubleValue] + [currentConsumableCount doubleValue]);
-          self.purchaseRecord[consumableId] = consumableCount;
-        } else {
-          // non-consumable or subscriptions
-          // subscriptions will eventually contain the expiry date after the receipt is validated during the next run
-          self.purchaseRecord[transaction.payment.productIdentifier] = [NSNull null];
-        }
-        [self savePurchaseRecord];
-        [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitProductPurchasedNotification
-                                                            object:transaction.payment.productIdentifier];
-      }
-        break;
     }
-  }
 }
 
-- (void) failedTransaction: (SKPaymentTransaction *)transaction {
-  
-  NSLog(@"Transaction Failed with error: %@", transaction.error);
-  [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
-  [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitProductPurchaseFailedNotification
-                                                      object:transaction.payment.productIdentifier];
+- (void)failedTransaction:(SKPaymentTransaction *)transaction inQueue:(SKPaymentQueue *)queue {
+    NSLog(@"Transaction Failed with error: %@", transaction.error);
+    [queue finishTransaction:transaction];
+    [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitProductPurchaseFailedNotification
+                                                        object:transaction.payment.productIdentifier];
+}
+
+- (void)deferredTransaction:(SKPaymentTransaction *)transaction inQueue:(SKPaymentQueue *)queue {
+    NSLog(@"Transaction Deferred: %@", transaction);
+    [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitProductPurchaseDeferredNotification
+                                                        object:transaction.payment.productIdentifier];
 }
 
 @end

--- a/README.mdown
+++ b/README.mdown
@@ -7,9 +7,9 @@ See the table below for details on MKStoreKit's requirements and compatibility.
 
 | Version | Stage  | Backwards Compatibility | iOS Version | OS X Version | Requires ARC |
 |:-------:|:------:|:-----------------------:|:-----------:|:------------:|:------------:|
-|   6.0   | Beta 1 | MKStoreKit Version 6.0  |   iOS 7.0   |    10.10 +   |      YES     |
+|   6.0   | Beta 1 | MKStoreKit Version 6.0  |  iOS 7.0 +  |    10.10 +   |      YES     |
 
-MKStoreKit 6 is a **complete revamp** of the project and is not compatible with previous versions of MKStoreKit. Refactoring should however be fairly simple. See the *Earliest Compatible Version* column to determine backwards compatibility.
+MKStoreKit 6 is a **complete revamp** of the project and is not compatible with previous versions of MKStoreKit. Refactoring should however be fairly simple. See the *Backwards Compatibility* column to determine the earliest comaptible version with the current release.
 
 *MKStoreKit 6 is still in early beta (see the Stage column). Use with caution*
 

--- a/README.mdown
+++ b/README.mdown
@@ -26,6 +26,7 @@ You then have to initialize it by calling `[[MKStoreKit sharedKit] startProductR
 * Built-in receipt validation (remote)
 * Built-in virtual currency manager
 * Support for iOS 8 Deferred Purchases, "Ask to Buy"
+* Works on iOS and Mac OS X
 
 ## Sample Code 
 
@@ -136,16 +137,14 @@ It can't get simpler than this!
 * Dynamically adding products to MKStoreKit from a remote resource
 * Keychain support for products
 * Support for hosted content
-* Local receipt verification using asn1c
+* Local receipt verification using ASN1C
 
 ## Untested Features
 
 * Non-renewing subscriptions
-* Free subscriptions for news stand
-* Mac OS X support
+* Free subscriptions for Newsstand
 
-
-These three features might work, but they are not tested yet.
+These two features might work, but they are not tested yet.
 
 
 ###Licensing

--- a/README.mdown
+++ b/README.mdown
@@ -3,10 +3,15 @@
 An in-App Purchase framework for iOS 7.0+. **MKStoreKit** makes in-App Purchasing super simple by remembering your purchases, validating reciepts, and tracking virtual currencies (consumable purchases). Additionally, it keeps track of auto-renewable subscriptions and their expirationd dates. It couldn't be easier!
 
 ## Compatibility
-This is version 6.0 beta 1 of MKStoreKit. iOS 7.0+ only. 
-MKStoreKit 6 is a **complete revamp**, and is not API compatible with previous versions of MKStoreKit. Refactoring should however be fairly simple.
+See the table below for details on MKStoreKit's requirements and compatibility.
 
-*The code base is still in early beta. Use with caution*
+| Version | Stage  | Earliest Compatible Version | iOS Version | OS X Version | Requires ARC |
+|:-------:|:------:|:---------------------------:|:-----------:|:------------:|:------------:|
+|   6.0   | Beta 1 |    MKStoreKit Version 6.0   |  iOS 7.0 +  | OS X 10.10 + |      YES     |
+
+MKStoreKit 6 is a **complete revamp** of the project and is not compatible with previous versions of MKStoreKit. Refactoring should however be fairly simple. See the *Earliest Compatible Version* column to determine backwards compatibility.
+
+*MKStoreKit 6 is still in early beta (see the Stage column). Use with caution*
 
 ## Setup
 The source code contains just three files:

--- a/README.mdown
+++ b/README.mdown
@@ -25,6 +25,7 @@ You then have to initialize it by calling `[[MKStoreKit sharedKit] startProductR
 * Built-in support for remembering your purchases
 * Built-in receipt validation (remote)
 * Built-in virtual currency manager
+* Support for iOS 8 Deferred Purchases, "Ask to Buy"
 
 ## Sample Code 
 
@@ -136,7 +137,6 @@ It can't get simpler than this!
 * Keychain support for products
 * Support for hosted content
 * Local receipt verification using asn1c
-* Support for iOS 8's "Ask to buy" (SKPaymentTransactionStateDeferred)
 
 ## Untested Features
 

--- a/README.mdown
+++ b/README.mdown
@@ -5,9 +5,9 @@ An in-App Purchase framework for iOS 7.0+. **MKStoreKit** makes in-App Purchasin
 ## Compatibility
 See the table below for details on MKStoreKit's requirements and compatibility.
 
-| Version | Stage  | Earliest Compatible Version | iOS Version | OS X Version | Requires ARC |
-|:-------:|:------:|:---------------------------:|:-----------:|:------------:|:------------:|
-|   6.0   | Beta 1 |    MKStoreKit Version 6.0   |  iOS 7.0 +  | OS X 10.10 + |      YES     |
+| Version | Stage  | Backwards Compatibility | iOS Version | OS X Version | Requires ARC |
+|:-------:|:------:|:-----------------------:|:-----------:|:------------:|:------------:|
+|   6.0   | Beta 1 | MKStoreKit Version 6.0  |   iOS 7.0   |    10.10 +   |      YES     |
 
 MKStoreKit 6 is a **complete revamp** of the project and is not compatible with previous versions of MKStoreKit. Refactoring should however be fairly simple. See the *Earliest Compatible Version* column to determine backwards compatibility.
 

--- a/README.mdown
+++ b/README.mdown
@@ -1,12 +1,24 @@
 #MKStoreKit
 
-This is version 6.0 beta 1 of MKStoreKit. iOS 7+ only. 
-MKStoreKit 6 is a **complete revamp** is not API compatible with previous versions of MKStoreKit. Refactoring should however be fairly simple.
+An in-App Purchase framework for iOS 7.0+. **MKStoreKit** makes in-App Purchasing super simple by remembering your purchases, validating reciepts, and tracking virtual currencies (consumable purchases). Additionally, it keeps track of auto-renewable subscriptions and their expirationd dates. It couldn't be easier!
+
+## Compatibility
+This is version 6.0 beta 1 of MKStoreKit. iOS 7.0+ only. 
+MKStoreKit 6 is a **complete revamp**, and is not API compatible with previous versions of MKStoreKit. Refactoring should however be fairly simple.
 
 *The code base is still in early beta. Use with caution*
 
-The source code contains just three files, MKStoreKit.h/m and MKStoreKitConfigs.plist
-The MKStoreKit is a singleton class that takes care of *everything*. Just drag these four files into the project. You then have to initialize it by calling [[MKStoreKit sharedKit] startProductRequest] in your application:didFinishLaunchingWithOptions. From then on, it does the magic. The MKStoreKit purchases, remembers and even handles remote validation of auto-renewable subscriptions.
+## Setup
+The source code contains just three files:
+* 'MKStoreKit.h'
+* 'MKStoreKit.m'
+* 'MKStoreKitConfigs.plist'
+
+The MKStoreKit is a singleton class that takes care of *everything*. 
+
+Just drag these three files into the project. 
+
+You then have to initialize it by calling `[[MKStoreKit sharedKit] startProductRequest]` in your `application:didFinishLaunchingWithOptions`. From then on, it does the magic. The MKStoreKit purchases, remembers and even handles remote validation of auto-renewable subscriptions.
 
 ## Features
 * Super simple in app purchasing
@@ -40,54 +52,54 @@ Initialization is as simple as calling
 A sample initialziation code that you can add to your application:didFinishLaunchingWithOptions: is below
 
 ``` objective-c
-  [[MKStoreKit sharedKit] startProductRequest];
+[[MKStoreKit sharedKit] startProductRequest];
   
-  [[NSNotificationCenter defaultCenter] addObserverForName:kMKStoreKitProductsAvailableNotification
-                                                    object:nil
-                                                     queue:[[NSOperationQueue alloc] init]
-                                                usingBlock:^(NSNotification *note) {
+[[NSNotificationCenter defaultCenter] addObserverForName:kMKStoreKitProductsAvailableNotification
+                                                  object:nil
+                                                   queue:[[NSOperationQueue alloc] init]
+                                              usingBlock:^(NSNotification *note) {
     
-    NSLog(@"Products available: %@", [[MKStoreKit sharedKit] availableProducts]);
-  }];
+                                                NSLog(@"Products available: %@", [[MKStoreKit sharedKit] availableProducts]);
+                                              }];
   
   
-  [[NSNotificationCenter defaultCenter] addObserverForName:kMKStoreKitProductPurchasedNotification
-                                                    object:nil
-                                                     queue:[[NSOperationQueue alloc] init]
-                                                usingBlock:^(NSNotification *note) {
+[[NSNotificationCenter defaultCenter] addObserverForName:kMKStoreKitProductPurchasedNotification
+                                                  object:nil
+                                                   queue:[[NSOperationQueue alloc] init]
+                                              usingBlock:^(NSNotification *note) {
                                                   
-                                                  NSLog(@"Purchased/Subscribed to product with id: %@", [note object]);
-                                                }];
+                                                NSLog(@"Purchased/Subscribed to product with id: %@", [note object]);
+                                              }];
   
-  [[NSNotificationCenter defaultCenter] addObserverForName:kMKStoreKitRestoredPurchasesNotification
-                                                    object:nil
-                                                     queue:[[NSOperationQueue alloc] init]
-                                                usingBlock:^(NSNotification *note) {
+[[NSNotificationCenter defaultCenter] addObserverForName:kMKStoreKitRestoredPurchasesNotification
+                                                  object:nil
+                                                   queue:[[NSOperationQueue alloc] init]
+                                              usingBlock:^(NSNotification *note) {
                                                   
-                                                  NSLog(@"Restored Purchases");
-                                                }];
+                                                NSLog(@"Restored Purchases");
+                                              }];
   
-  [[NSNotificationCenter defaultCenter] addObserverForName:kMKStoreKitRestoringPurchasesFailedNotification
-                                                    object:nil
-                                                     queue:[[NSOperationQueue alloc] init]
-                                                usingBlock:^(NSNotification *note) {
+[[NSNotificationCenter defaultCenter] addObserverForName:kMKStoreKitRestoringPurchasesFailedNotification
+                                                  object:nil
+                                                   queue:[[NSOperationQueue alloc] init]
+                                              usingBlock:^(NSNotification *note) {
                                                   
-                                                  NSLog(@"Failed restoring purchases with error: %@", [note object]);
-                                                }];
+                                                 NSLog(@"Failed restoring purchases with error: %@", [note object]);
+                                              }];
 ```
 
 ###Checking Product Status
 You can check if a product was previously purchased using -isProductPurchased as shown below.
 ``` objective-c
-if([MKStoreManager isProductPurchased:productIdentifier]) {
-//unlock it
+if ([[MKStoreKit sharedKit] isProductPurchased:productIdentifier]) {
+        // Unlock it
 }
 ```
 
 You can check for a product's expiry date using -expiryDateForProduct as shown below.
 ``` objective-c
-if([MKStoreManager expiryDateForProduct:productIdentifier]) {
-//unlock it
+if ([[MKStoreKit sharedKit] expiryDateForProduct:productIdentifier]) {
+        // Unlock it
 }
 ```
 
@@ -104,16 +116,15 @@ To purchase a feature or to subscribe to a auto-renewing subscription, just call
 Observe kMKStoreKitProductPurchasedNotification to get notified when the purchase completes
 
 ``` objective-c
-
-  [[NSNotificationCenter defaultCenter] addObserverForName:kMKStoreKitProductPurchasedNotification
-                                                    object:nil
-                                                     queue:[[NSOperationQueue alloc] init]
-                                                usingBlock:^(NSNotification *note) {
+[[NSNotificationCenter defaultCenter] addObserverForName:kMKStoreKitProductPurchasedNotification
+                                                  object:nil
+                                                   queue:[[NSOperationQueue alloc] init]
+                                              usingBlock:^(NSNotification *note) {
                                                   
                                                   NSLog(@"Purchased/Subscribed to product with id: %@", [note object]);
                                                   
                                                   NSLog(@"%@", [[MKStoreKit sharedKit] valueForKey:@"purchaseRecord"]);
-                                                }];
+                                              }];
 ```
 
 It can't get simpler than this!

--- a/README.mdown
+++ b/README.mdown
@@ -10,9 +10,9 @@ MKStoreKit 6 is a **complete revamp**, and is not API compatible with previous v
 
 ## Setup
 The source code contains just three files:
-* 'MKStoreKit.h'
-* 'MKStoreKit.m'
-* 'MKStoreKitConfigs.plist'
+* `MKStoreKit.h`
+* `MKStoreKit.m`
+* `MKStoreKitConfigs.plist`
 
 The MKStoreKit is a singleton class that takes care of *everything*. 
 


### PR DESCRIPTION
### Deferred Purchases
Added support for deferred purchases on iOS 8.0 and up. Use the `kMKStoreKitProductPurchaseDeferredNotification` key to get notifications about deferred purchases. 

### Mac OS X Compatibility
Tested for and fixed compile-time errors on Mac OS X. The necessary code now loads conditionally at compile time using macros to detect a build target for iOS or OS X.

### Bug Fixes
Fixed bug where no notification was sent when a purchase failed. Fixes #205. Fixes #196.

### Readme Updates
Added brief description at the beginning. Separated the first block of text into *Compatibility* and *Setup* sections. Fixed some errors and formatting issues in the sample code.

The Readme now reflects the new Mac OS X compatibility by removing it from the *Untested* list. Moved Deferred Purchases from the *Missing* list to the features list.

Added a nice pretty little table to the Readme to depict the compatibility requirements.