### PR TITLE
App Version Checking, Receipt Refresh, Bug Fixes

### DIFF
--- a/MKStoreKit.h
+++ b/MKStoreKit.h
@@ -156,6 +156,16 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
 - (void)restorePurchases;
 
 /*!
+ *  @abstract Refreshes the App Store receipt and prompts the user to authenticate.
+ *
+ *  @discussion
+ *	This method can generate a reciept while debugging your application. In a production
+ *  environment this should only be used in an appropriate context because it will present
+ *  an App Store login alert to the user (without explanation).
+ */
+- (void)refreshAppStoreReceipt;
+
+/*!
  *  @abstract Initiates payment request for a In App Purchasable Product
  *
  *  @discussion
@@ -168,6 +178,20 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
  *  -expiryDateForProduct
  */
 - (void)initiatePaymentRequestForProductWithIdentifier:(NSString *)productId;
+
+/*!
+ *  @abstract Checks whether the app version the user purchased is older than the required version
+ *
+ *  @discussion
+ *	This method checks against the local store maintained by MKStoreKit when the app was originally purchased
+ *  This method can be used to determine if a user should recieve a free upgrade. For example, apps transitioning
+ *  from a paid system to a freemium system can determine if users are "grandfathered-in" and exempt from extra
+ *  freemium purchases.
+ *
+ *  @seealso
+ *  -isProductPurchased
+ */
+- (BOOL)purchasedAppBeforeVersion:(NSString *)requiredVersion;
 
 /*!
  *  @abstract Checks whether the product identified by the given productId is purchased previously


### PR DESCRIPTION
### New Features
Added a new API to check for the original app purchase date, `purchasedAppBeforeVersion:`. This API will help apps transitioning from a paid model to a freemium model by allowing them to exempt users who previously purchased the app.

Refresh the StoreKit receipt by calling the new `refreshAppStoreReceipt` API. This may be useful when debugging and there is no receipt available yet.

### Bug Fixes
Fixed a crash that occurred when validating a receipt. At runtime, the system would throw an exception because (on line 341) the NSNumber `previouslyStoredExpiresDateMs` may be Null during a comparison (NSNull doubleValue). 

Resolved some issues with receipt validation and added a new error code, 21009.The 21009 error code depicts an error where there is no receipt at all. In this event, one should use the new refresh receipt API.