### PR TITLE
Configure Subscription Durations

### DIFF
--- a/MKStoreKit.h
+++ b/MKStoreKit.h
@@ -210,6 +210,17 @@ extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
 - (BOOL)isProductPurchased:(NSString *)productId;
 
 /*!
+ *  @abstract Returns the duration of an auto-renewing subscription product
+ *
+ *  @discussion
+ *	This method reads the duration from MKStoreKitConfigs.plist
+ *
+ *  @seealso
+ *  -expiryDateForProduct
+ */
+- (NSInteger)subscriptionDurationForProduct:(NSString *)productId;
+
+/*!
  *  @abstract Checks the expiry date for the product identified by the given productId
  *
  *  @discussion

--- a/MKStoreKit.m
+++ b/MKStoreKit.m
@@ -157,6 +157,13 @@ static NSDictionary *errorDictionary;
   return [self.purchaseRecord.allKeys containsObject:productId];
 }
 
+- (NSInteger)subscriptionDurationForProduct:(NSString *)productId {
+    NSDictionary *subscriptions = [MKStoreKit configs][@"Subscriptions"];
+    NSNumber *duration = subscriptions[productId];
+    if (nil == duration) return -1;
+    return [duration integerValue];
+}
+
 -(NSDate*) expiryDateForProduct:(NSString*) productId {
   
   NSNumber *expiresDateMs = self.purchaseRecord[productId];
@@ -189,10 +196,12 @@ static NSDictionary *errorDictionary;
   NSMutableArray *productsArray = [NSMutableArray array];
   NSArray *consumables = [[MKStoreKit configs][@"Consumables"] allKeys];
   NSArray *others = [MKStoreKit configs][@"Others"];
-  
+  NSArray *subscriptions = [[MKStoreKit configs][@"Subscriptions"] allKeys];
+
   [productsArray addObjectsFromArray:consumables];
   [productsArray addObjectsFromArray:others];
-  
+  [productsArray addObjectsFromArray:subscriptions];
+
   SKProductsRequest *productsRequest = [[SKProductsRequest alloc]
                                         initWithProductIdentifiers:[NSSet setWithArray:productsArray]];
   productsRequest.delegate = self;

--- a/README.mdown
+++ b/README.mdown
@@ -39,10 +39,11 @@ It's close to impossible to maintain a working sample code for MKStoreKit as iTu
 
 ###Config File Format
 MKStoreKit uses a config file, MKStoreKitConfigs.plist for managing your product identifiers.
-The config file is a Plist dictionary containing three keys, "Consumables", "Others" and "SharedSecret"
+The config file is a Plist dictionary containing three keys, "Consumables", "Subscriptions", "Others" and "SharedSecret"
 
-Consumables is the key where you provide a list of consumables in your app that should be managed as a virtual currency.
-Others is the key where you provide a list of in app purchasable products
+Consumables is the key where you provide a list of consumables in your app that should be managed as a virtual currency.  
+Subscriptions is the key where you provide a list of subscriptions and their durations.  
+Others is the key where you provide a list of in app purchasable products.  
 SharedSecret is the key where you provide the shared secret generated on your iTunesConnect account.
 
 Here is a sample [MKStoreKitConfigs.plist](https://gist.github.com/MugunthKumar/330fc38b542c96fcecc6)


### PR DESCRIPTION
I added support for storing the duration of a subscription product in MKStoreKitConfigs.plist, and later retrieving it using -subscriptionDurationForProduct:  
This is useful for presenting the price per month in a shopfront (as recommended by Apple).

I updated he sample MKStoreKitConfigs.plist accordingly -- see my fork at https://gist.github.com/yonat/5f803b7ef84619711926