### PR TITLE
[MKStoreKit-notificationForStore]

### DIFF
--- a/MKStoreKit.h
+++ b/MKStoreKit.h
@@ -106,6 +106,12 @@ extern NSString *const kMKStoreKitReceiptValidationFailedNotification;
  */
 extern NSString *const kMKStoreKitSubscriptionExpiredNotification;
 
+extern NSString *const kMKStoreKitSubscriptionTransactionCompletedNotification;
+
+/*!
+ *  @abstract This notification is posted when MKStoreKit completed subscribing to AppStore.
+ */
+
 
 /*!
  *  @abstract The singleton class that takes care of In App Purchasing

--- a/MKStoreKit.m
+++ b/MKStoreKit.m
@@ -47,6 +47,8 @@ NSString *const kMKStoreKitRestoredPurchasesNotification = @"com.mugunthkumar.mk
 NSString *const kMKStoreKitRestoringPurchasesFailedNotification = @"com.mugunthkumar.mkstorekit.failedrestoringpurchases";
 NSString *const kMKStoreKitReceiptValidationFailedNotification = @"com.mugunthkumar.mkstorekit.failedvalidatingreceipts";
 NSString *const kMKStoreKitSubscriptionExpiredNotification = @"com.mugunthkumar.mkstorekit.subscriptionexpired";
+NSString *const kMKStoreKitSubscriptionTransactionCompletedNotification =
+@"com.mugunthkumar.mkstorekit.subscriptionCompleted";
 
 NSString *const kSandboxServer = @"https://sandbox.itunes.apple.com/verifyReceipt";
 NSString *const kLiveServer = @"https://buy.itunes.apple.com/verifyReceipt";
@@ -222,6 +224,7 @@ static NSDictionary *errorDictionary;
 
 - (void)paymentQueue:(SKPaymentQueue *)queue restoreCompletedTransactionsFailedWithError:(NSError *)error {
   [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitRestoringPurchasesFailedNotification object:error];
+    [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitSubscriptionTransactionMadeNotification object:error];
 }
 
 - (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue {
@@ -418,6 +421,8 @@ static NSDictionary *errorDictionary;
 
 - (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions {
   for (SKPaymentTransaction *transaction in transactions) {
+      transaction.transactionState != SKPaymentTransactionStatePurchasing ? [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitSubscriptionTransactionCompletedNotification object:transaction] : nil;
+
     switch (transaction.transactionState) {
         
       case SKPaymentTransactionStatePurchasing:


### PR DESCRIPTION
Suppose we need to have an opportunity to observe connection to appstore.
For an instance, in order to show progress hud while waiting response.  
After subscription is completed - to post notification.