### PR TITLE
Added notification for "Invalid Product IDs"

### DIFF
--- a/MKStoreKit/MKStoreKit.h
+++ b/MKStoreKit/MKStoreKit.h
@@ -65,6 +65,12 @@
  */
 extern NSString *const kMKStoreKitProductsAvailableNotification;
 
+
+/*!
+ *  @abstract This notification is posted when if MKStoreKit finds invalid product ids after initialization sequence
+ */
+extern NSString *const kMKStoreKitProductsInvalidIdsNotification;
+
 /*!
  *  @abstract This notification is posted when MKStoreKit completes purchase of a product
  */

--- a/MKStoreKit/MKStoreKit.m
+++ b/MKStoreKit/MKStoreKit.m
@@ -40,6 +40,7 @@
 
 @import StoreKit;
 NSString *const kMKStoreKitProductsAvailableNotification = @"com.mugunthkumar.mkstorekit.productsavailable";
+NSString *const kMKStoreKitProductsInvalidIdsNotification = @"com.mugunthkumar.mkstorekit.productsinvalidids";
 NSString *const kMKStoreKitProductPurchasedNotification = @"com.mugunthkumar.mkstorekit.productspurchased";
 NSString *const kMKStoreKitProductPurchaseFailedNotification = @"com.mugunthkumar.mkstorekit.productspurchasefailed";
 NSString *const kMKStoreKitProductPurchaseDeferredNotification = @"com.mugunthkumar.mkstorekit.productspurchasedeferred";
@@ -214,7 +215,8 @@ static NSDictionary *errorDictionary;
 
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {
   if (response.invalidProductIdentifiers.count > 0) {
-    NSLog(@"Invalid Product IDs: %@", response.invalidProductIdentifiers);
+    [[NSNotificationCenter defaultCenter] postNotificationName:kMKStoreKitProductsInvalidIdsNotification
+                                                        object:response.invalidProductIdentifiers];
   }
 
   self.availableProducts = response.products;


### PR DESCRIPTION
Add additional notification for "Invalid Product IDs" (kMKStoreKitProductsInvalidIdsNotification), replaced NSLog() call with the aforementioned notification.